### PR TITLE
Create db with encoding UTF8

### DIFF
--- a/.scripts/databases.mk
+++ b/.scripts/databases.mk
@@ -21,7 +21,7 @@ ensure-databases: $(addprefix .ensure-database-, $(databases))
 	if psql -lqt | cut -d \| -f 1 | grep -qw $($*) ; then \
 		echo "$* database exists"; \
 	else \
-		psql postgres -c "create database $($*);"; \
+		psql postgres -c "create database $($*) with encoding='UTF8';"; \
 	fi;
 
 


### PR DESCRIPTION
Postgres by default uses the default encoding `SQL_ASCII`. The build (calling `make`) fails when `SQL_ASCII` is used.

With this change, it is not necessary anymore to change the default encoding in Postgres to be able to call `make` without encoding issues.