### PR TITLE
Integrate mara markdown docs

### DIFF
--- a/.scripts/mara-mondrian/mondrian-server.mk
+++ b/.scripts/mara-mondrian/mondrian-server.mk
@@ -1,7 +1,7 @@
 # properties file setup, run mondrian-server locally
 
 mondrian-server-directory ?= .mondrian-server
-mondrian-server-properties-file := $(mondrian-server-directory)/mondrian-server.propertiess
+mondrian-server-properties-file := $(mondrian-server-directory)/mondrian-server.properties
 saiku-storage-directory ?= $(mondrian-server-directory)/saiku-queries
 
 mondrian-server-db ?= dwh
@@ -38,9 +38,9 @@ $(saiku-storage-directory):
 
 $(mondrian-server-properties-file): $(mondrian-server-directory)
 	cat $(mara-mondrian-package-dir)/mondrian-server.properties.example \
-	   | sed 's@/absolute/path/to/mondrian-schema.xml@$(mondrian-schema-file)@g' \
-	   | sed 's@^databaseUrl.*@databaseUrl=$(mondrian-server-db-connection-url)@g' \
-	   | sed 's@^saikuStorageDir.*@saikuStorageDir=$(saiku-storage-directory)@g' \
+	   | sed 's§/absolute/path/to/mondrian-schema.xml§$(mondrian-schema-file)§g' \
+	   | sed 's§^databaseUrl.*§databaseUrl=$(mondrian-server-db-connection-url)§g' \
+	   | sed 's§^saikuStorageDir.*§saikuStorageDir=$(saiku-storage-directory)§g' \
 	   > $(mondrian-server-properties-file)
 	>&2 echo '!!! copied $(mara-mondrian-package-dir)/mondrian-server.properties.example to $(mondrian-server-properties-file). Please check'
 

--- a/app/ui/__init__.py
+++ b/app/ui/__init__.py
@@ -1,24 +1,28 @@
 """Set up Navigation, ACL & Logos"""
 
-import mara_pipelines
-import mara_data_explorer
+import pathlib
+
 import flask
 import mara_acl
+import mara_acl.config
+import mara_acl.permissions
 import mara_acl.users
 import mara_app
+import mara_app.config
 import mara_app.layout
+import mara_data_explorer
 import mara_db
+import mara_markdown_docs.config
+import mara_metabase
+import mara_metabase.config
+import mara_mondrian
+import mara_mondrian.config
 import mara_page.acl
+import mara_pipelines
+import mara_schema
 from mara_app import monkey_patch
 from mara_page import acl
 from mara_page import navigation
-import mara_mondrian.config
-import mara_mondrian
-import mara_metabase.config
-import mara_metabase
-
-import mara_schema
-import olist_ecommerce
 
 from app.ui import start_page
 
@@ -52,11 +56,11 @@ def acl_resources():
             acl.AclResource(name='Data',
                             children=[*mara_data_explorer.MARA_ACL_RESOURCES().values(),
                                       *mara_metabase.MARA_ACL_RESOURCES().values(),
-                                      *mara_mondrian.MARA_ACL_RESOURCES().values()
-                            ]),
+                                      *mara_mondrian.MARA_ACL_RESOURCES().values()]),
             acl.AclResource(name='Admin',
                             children=[mara_app.MARA_ACL_RESOURCES().get('Configuration'),
-                                      mara_acl.MARA_ACL_RESOURCES().get('Acl')])]
+                                      mara_acl.MARA_ACL_RESOURCES().get('Acl')])
+            ]
 
 
 # activate ACL
@@ -78,7 +82,27 @@ def navigation_root() -> navigation.NavigationEntry:
         *mara_schema.MARA_NAVIGATION_ENTRIES().values(),
         *mara_pipelines.MARA_NAVIGATION_ENTRIES().values(),
         *mara_db.MARA_NAVIGATION_ENTRIES().values(),
+        *mara_markdown_docs.MARA_NAVIGATION_ENTRIES().values(),
         navigation.NavigationEntry(
             'Settings', icon='cog', description='ACL & Configuration', rank=100,
             children=[*mara_app.MARA_NAVIGATION_ENTRIES().values(),
-                      *mara_acl.MARA_NAVIGATION_ENTRIES().values()])])
+                      *mara_acl.MARA_NAVIGATION_ENTRIES().values()]),
+    ])
+
+
+@monkey_patch.patch(mara_markdown_docs.config.documentation)
+def documentation() -> dict:
+    """Dict with name -> path to markdown file.
+
+    If name contains a single '/' it will be shown in a submenu. Multiple '/' are not allowed.
+    The insertion order is mostly preserved (folders are grouped in the menu)."""
+
+    repo_root_dir = pathlib.Path(__file__).parent.parent.parent
+
+    # Cases matter in path!
+    docs = {
+        'Olist Data': repo_root_dir / 'docs/olist-data.md',
+        'Developer/Setup': repo_root_dir / 'README.md',
+    }
+
+    return docs

--- a/docs/olist-data.md
+++ b/docs/olist-data.md
@@ -13,10 +13,10 @@ Its features allow viewing a sales process from multiple dimensions: lead catego
 The total size of this data is 121MB and is included as a project requirement from the
 [olist-ecommerce-data](https://github.com/mara/olist-ecommerce-data) package for ease of loading.
 
-Then, there is the ETL in [app/pipelines](app/pipelines) that transforms 
+Then, there is the ETL in [app/pipelines](/app/pipelines) that transforms 
 this data into a classic Kimball-like [star schema](https://en.wikipedia.org/wiki/Star_schema):
 
-![Star schema](docs/star-schema.png)
+![Star schema](star-schema.png)
 
 It shows 2 database schemas, each created by a different pipeline: 
 
@@ -63,13 +63,13 @@ LIMIT 10;
 
 The Mara pipelines are visualized and debugged though a web ui. Here, the pipeline `e_commerce` is run (locally on an Ubuntu 18.04 with all available data): 
 
-![Mara web ui ETL run](docs/mara-web-ui-etl-run.gif)
+![Mara web ui ETL run](mara-web-ui-etl-run.png)
 
 &nbsp;
 
 On production, pipelines are run through a cli interface:
 
-![Mara cli ETL run](docs/mara-cli-etl-run.gif)
+![Mara cli ETL run](mara-cli-etl-run.png)
 
 &nbsp;
 
@@ -77,7 +77,7 @@ Mara ETL pipelines are completely transparent, both to stakeholders in terms of 
 
 This is the page in the web ui that visualizes the pipeline `e_commerce`: 
 
-![Mara web UI for pipelines](docs/mara-web-ui-pipeline.png)
+![Mara web UI for pipelines](mara-web-ui-pipeline.png)
 
 It shows 
 
@@ -90,7 +90,7 @@ It shows
 
 Similarly, this is the page for the task `e_commerce/transform_order_item`:
 
-![Mara web ui for tasks](docs/mara-web-ui-task.png)
+![Mara web ui for tasks](mara-web-ui-task.png)
 
 It shows its
 
@@ -110,7 +110,7 @@ and ensures consistency across reporting tools and transparency to the DWH users
 The package has a web UI for documentation of the business semantics in a DWH: 
 Entities, Attributes, Metrics, DataSets, etc.
 
-![Mara schema documentation overview](docs/mara-schema-documentation-overview.png)
+![Mara schema documentation overview](mara-schema-documentation-overview.png)
 
 The [mara-schema/schema](https://github.com/mara/mara-schema/tree/master/mara_schema/schema) directory,
 contains modules with classes for `DataSet`, `Entity`, `Metric`, `Attribute`, etc.
@@ -122,7 +122,7 @@ directory, contains modules with functions that generate SQL for flattened table
 Please take a look at the pipeline [generate_artifacts](https://github.com/mara/mara-example-project-1/blob/master/app/pipelines/generate_artifacts/__init__.py),
 which shows an example of using Mara Schema to automate the generation of artifacts:
 
-![Generate artifacts pipeline](docs/generate-artifacts-pipeline.png)
+![Generate artifacts pipeline](generate-artifacts-pipeline.png)
 
 The following flask command generates an XML file for Mondrian schema in an activated virtual environment.
 Please check the [README.md](https://github.com/mara/mara-schema/blob/master/README.md#create-mondrian-schema) for the configuration.

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@
 
 -e git+https://git@github.com/mara/mara-olist-ecommerce-data.git@master#egg=mara-olist-ecommerce-data
 
+-e git+https://github.com/mara/mara-markdown-docs.git@master#egg=mara-markdown-docs
+
 
 # running flask
 gunicorn

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@
 -e git+https://github.com/mara/mara-etl-tools.git@4.0.0#egg=mara-etl-tools
 -e git+https://github.com/mara/mara-schema.git@master#egg=mara-schema
 -e git+https://github.com/mara/mara-data-explorer.git@3.0.0#egg=mara-data-explorer
--e git+https://github.com/mara/mara-mondrian.git@1.0.1#egg=mara-mondrian
+-e git+https://github.com/mara/mara-mondrian.git@1.0.2#egg=mara-mondrian
 -e git+https://github.com/mara/mara-metabase.git@1.0.1#egg=mara-metabase
 
 -e git+https://git@github.com/mara/mara-olist-ecommerce-data.git@master#egg=mara-olist-ecommerce-data

--- a/requirements.txt.freeze
+++ b/requirements.txt.freeze
@@ -19,7 +19,7 @@ Mako==1.1.3
 -e git+https://github.com/mara/mara-db.git@817bf658e918bf8dfd0c34236404eada5f0e28fd#egg=mara_db
 -e git+https://github.com/mara/mara-etl-tools.git@55bb4e8729af44bd8ccb88f9cb95dd3eef81ecee#egg=mara_etl_tools
 -e git+https://github.com/mara/mara-metabase.git@503f6d1172783fc6ec46a4362bf40fc10f6c8002#egg=mara_metabase
--e git+https://github.com/mara/mara-mondrian.git@a54a91608a7da8317217bdb927d7de34b97a32ed#egg=mara_mondrian
+-e git+https://github.com/mara/mara-mondrian.git@fd1d064490cfcfa3e1694cc1d4fdec6c257ffff5#egg=mara_mondrian
 -e git+https://git@github.com/mara/mara-olist-ecommerce-data.git@663660edff1b4cd711a172027081915771628b9f#egg=mara_olist_ecommerce_data
 -e git+https://github.com/mara/mara-page.git@c499a6c44aaa638c1515c3a857e5f68cad8b84c9#egg=mara_page
 -e git+https://github.com/mara/mara-pipelines.git@ab41e916be81969212f2f0e95a6b0e5794dd800d#egg=mara_pipelines

--- a/requirements.txt.freeze
+++ b/requirements.txt.freeze
@@ -18,6 +18,7 @@ Mako==1.1.3
 -e git+https://github.com/mara/mara-data-explorer.git@77803fcf07516aae163bb709c9f4b8105896e0bb#egg=mara_data_explorer
 -e git+https://github.com/mara/mara-db.git@817bf658e918bf8dfd0c34236404eada5f0e28fd#egg=mara_db
 -e git+https://github.com/mara/mara-etl-tools.git@55bb4e8729af44bd8ccb88f9cb95dd3eef81ecee#egg=mara_etl_tools
+-e git+https://github.com/mara/mara-markdown-docs.git@163f13a491dc7fd95dd299268216eab0705d2d7d#egg=mara_markdown_docs
 -e git+https://github.com/mara/mara-metabase.git@503f6d1172783fc6ec46a4362bf40fc10f6c8002#egg=mara_metabase
 -e git+https://github.com/mara/mara-mondrian.git@fd1d064490cfcfa3e1694cc1d4fdec6c257ffff5#egg=mara_mondrian
 -e git+https://git@github.com/mara/mara-olist-ecommerce-data.git@663660edff1b4cd711a172027081915771628b9f#egg=mara_olist_ecommerce_data


### PR DESCRIPTION
The main points here:

* Cleanup and rename the docs/olist-data.md file so that images are shown on github and mara-markdown-docs (the md file still needs more work as some screenshots are missing)
* Integrate mara-markdown-docs
* Update mara-mondrian to get a makefile fix

If the mara-md-docs integration should no be, the other fixes might still be nice to cherry pick.